### PR TITLE
Fix empty recruit tag combination

### DIFF
--- a/Arknights/addons/recruit_calc.py
+++ b/Arknights/addons/recruit_calc.py
@@ -47,13 +47,16 @@ def calculate(tags):
         if len(operators):
             operator_for_tags[comb3] = operators
 
+    result = {}
     for tags in operator_for_tags:
         ops = list(operator_for_tags[tags])
         if '高级资深干员' not in tags:
             ops = [op for op in ops if op[1] != 5]
-        ops.sort(key=lambda x: x[1], reverse=True)
-        operator_for_tags[tags] = ops
-    items = list(operator_for_tags.items())
+        if len(ops):
+            ops.sort(key=lambda x: x[1], reverse=True)
+            result[tags] = ops
+
+    items = list(result.items())
     combs = [(tags, ops, _rank(ops)) for tags, ops in items]
     return sorted(combs, key=lambda x: x[2], reverse=True)
 


### PR DESCRIPTION
修复公招的小 bug，在没有高资时，增加判断，移除空的 tag 组合。

一个具体例子是高资+快活+输出能锁傀影，但是没有高资时，快活+输出是冲突的。原先的代码，在没有高资时移除傀影，留下空的快活+输出组合。现在加了判断，移除六星干员后，如果组合是空的，就把这个组合也去掉。